### PR TITLE
Remove newline from versionhash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ sbserv: $(GO_FILES)
 	go build
 
 $(DATA_DIR)/version_hash: .git
-	git rev-parse HEAD > $(DATA_DIR)/version_hash
+	printf "%s" "$$(git rev-parse HEAD)" > $(DATA_DIR)/version_hash
 
 bindata.go: $(DATA_FILES)
 	go get github.com/jteeuwen/go-bindata/...


### PR DESCRIPTION
The make file used to build version hash with a newline, which would
cause issues when we load that file as the version hash appended to
static content
When that turned into a URL the string had %0a in it which is an invalid
character in URLs according to rfc2396