### PR TITLE
Adding Download buttons and download all files option

### DIFF
--- a/data/static/css/dir_listing.css
+++ b/data/static/css/dir_listing.css
@@ -1,8 +1,8 @@
 .iconButton {
     display: inline-block;
     float: right;
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-left: 6px;
+    padding-right: 6px;
 }
 .timeColumn {
     text-align: right;

--- a/data/static/js/dir_listing.js
+++ b/data/static/js/dir_listing.js
@@ -25,3 +25,18 @@ $('.moviePanel').on('show.bs.collapse', function () {
   var type = $(this).attr('type');
   $(this).html("<video controls><source src='" + src + "' type='"+ type +"'></video>");
 })
+
+$('.dlfiles-div').on('click', function (){
+  var downloadNodes = document.querySelectorAll('.downloadFileLink');
+  for (var i = 0; i < downloadNodes.length; i++) {
+    downloadNodes[i].click();
+  }
+});
+
+function DownloadAllFiles() {
+  var downloadNodes = document.querySelectorAll('.downloadFileLink');
+  for (var i = 0; i < downloadNodes.length; i++) {
+    downloadNodes[i].click();
+  }
+  return downloadNodes;
+}

--- a/data/templates/dir_listing.html
+++ b/data/templates/dir_listing.html
@@ -27,7 +27,10 @@
       <input type="submit">
     </form>
     <div class="dldir-div">
-      <a href="{{.Path}}?dldir=true">Download this directory</a>
+      <a href="{{.Path}}?dldir=true">Download as .zip</a>
+    </div>
+    <div class="dlfiles-div">
+      <a href="#">Download all files individually</a>
     </div>
     <div>
       <a href=".">
@@ -50,14 +53,21 @@
               <tr class="fileEntry">
                 <td>
                   <div>
-                    <a href="{{.Path}}">
+                    <a class="{{.Type}}" href="{{.Path}}">
                       <span class="glyphicon {{.Glyphicon}}"></span>
                       {{.Name}}
                     </a>
                     {{if .IsDir}}
                     <div class="downloadFolderButton iconButton" title="Download Folder as .zip">
-                      <a href="{{.Path}}?dldir=true">
+                      <a href="{{.Path}}?dldir=true" download="{{.Name}}.zip">
                       <span class="glyphicon glyphicon-cloud-download"></span>
+                      </a>
+                    </div>
+                    {{end}}
+                    {{if not .IsDir}}
+                    <div class="downloadFileButton iconButton" title="Download File">
+                      <a class = "downloadFileLink" href="{{.Path}}" download="{{.Name}}">
+                      <span class="glyphicon glyphicon-save"></span>
                       </a>
                     </div>
                     {{end}}


### PR DESCRIPTION
Resolves  #12 and is a better version of #18 
Makes three changes:
1. Adds a download button to all files that explicitly downloads the file (using HTML download tag). This helps set filenames for certain files that browsers get confused for
2. Sets the files name when a download is downloaded as a folder (I took a shortcut and just did it when clicking next to a folder, not the top bar, I didn't want to pipe through folder name in go)
3. Adds a button that uses JS to click all of the file download buttons in a folder. This makes it easy to download all files individually inside a folder if you don't want it as a zip. This is useful for really large folders that you want to download incrementally.