### PR TITLE
Changing CDN to support HTTPS

### DIFF
--- a/data/templates/dir_listing.html
+++ b/data/templates/dir_listing.html
@@ -7,7 +7,7 @@
     <title>Directory {{.Path}}</title>
 
     <!-- Bootstrap -->
-    <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
     
     <link href="/_static/{{.VHash}}/css/dir_listing.css" rel="stylesheet">
 
@@ -99,9 +99,9 @@
     </div>
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
-    <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
     <script src="/_static/{{.VHash}}/js/jquery.tablesorter.combined.min.js"></script>
     <script src="/_static/{{.VHash}}/js/dir_listing.js"></script>
   </body>


### PR DESCRIPTION
The bootstrap CDN had issues with HTTPS, not sure if its a temporary outage or permanent non support. Either way, moving to the CloudFlare CDN fixed it.